### PR TITLE
Move MultiBankApplication to root package

### DIFF
--- a/src/main/java/com/multibank/MultiBankApplication.java
+++ b/src/main/java/com/multibank/MultiBankApplication.java
@@ -1,4 +1,4 @@
-package com.multibank.application;
+package com.multibank;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/test/java/com/multibank/MultiBankApplicationTests.java
+++ b/src/test/java/com/multibank/MultiBankApplicationTests.java
@@ -1,6 +1,6 @@
 package com.multibank;
 
-import com.multibank.application.MultiBankApplication;
+import com.multibank.MultiBankApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 


### PR DESCRIPTION
## Summary
- move `MultiBankApplication` into the root `com.multibank` package so component scanning reaches all modules
- update the test context configuration to reference the relocated application class

## Testing
- mvn spring-boot:run *(fails: 403 retrieving dependencies from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1bf4ace8832ab4e3c6f92c0b91e4