### PR TITLE
Add home endpoint for API overview

### DIFF
--- a/src/main/java/com/multibank/controller/HomeController.java
+++ b/src/main/java/com/multibank/controller/HomeController.java
@@ -1,0 +1,28 @@
+package com.multibank.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public Map<String, Object> index() {
+        return Map.of(
+                "message", "MultiBank API is running.",
+                "availableEndpoints", List.of(
+                        "POST /api/banks/sync",
+                        "GET /api/banks/accounts",
+                        "GET /api/transactions",
+                        "GET /api/analytics/monthly-spending",
+                        "GET /api/analytics/category-totals",
+                        "POST /api/savings",
+                        "POST /api/savings/{id}/contribute",
+                        "POST /api/qr"
+                )
+        );
+    }
+}

--- a/src/test/java/com/multibank/controller/HomeControllerTest.java
+++ b/src/test/java/com/multibank/controller/HomeControllerTest.java
@@ -1,0 +1,27 @@
+package com.multibank.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void rootEndpointProvidesHelpfulMessage() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("MultiBank API is running."))
+                .andExpect(jsonPath("$.availableEndpoints").isArray());
+    }
+}


### PR DESCRIPTION
## Summary
- add a HomeController that exposes the root endpoint with a friendly status message and list of useful APIs
- cover the new endpoint with a MockMvc test to ensure the response structure remains stable

## Testing
- mvn test *(fails: Unable to download parent POM because Maven Central returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1eaa8308832a9fa7372e8725896e